### PR TITLE
Update hdkey.js

### DIFF
--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -60,13 +60,17 @@ Object.defineProperty(HDKey.prototype, 'publicKey', {
 
 Object.defineProperty(HDKey.prototype, 'privateExtendedKey', {
   get: function() {
-    return cs.encode(serialize(this, this.versions.private, Buffer.concat([new Buffer([0]), this.privateKey])))
+    if(this.versions.bip32)
+      return cs.encode(serialize(this, this.versions.bip32.private, Buffer.concat([new Buffer([0]), this.privateKey])))
+   
   }
 })
 
 Object.defineProperty(HDKey.prototype, 'publicExtendedKey', {
   get: function() {
-    return cs.encode(serialize(this, this.versions.public, this.publicKey))
+    if(this.versions.bip32)
+      return cs.encode(serialize(this, this.versions.bip32.public, this.publicKey))
+    
   }
 })
 


### PR DESCRIPTION
To encode the xpub and xpriv keys, use versions.bip32 instead of versions
