### PR TITLE
hdkey: use bippath for BIP32 path parsing and validation

### DIFF
--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -2,6 +2,7 @@ var assert = require('assert')
 var crypto = require('crypto')
 var cs = require('coinstring')
 var secp256k1 = require('secp256k1')
+var bip32path = require('bip32-path')
 
 var MASTER_SECRET = new Buffer('Bitcoin seed')
 var HARDENED_OFFSET = 0x80000000
@@ -72,19 +73,9 @@ HDKey.prototype.derive = function (path) {
     return this
   }
 
-  var entries = path.split('/')
   var hdkey = this
-  entries.forEach(function (c, i) {
-    if (i === 0) {
-      assert(c, 'm', 'Invalid path')
-      return
-    }
 
-    var hardened = (c.length > 1) && (c[c.length - 1] === "'")
-    var childIndex = parseInt(c, 10) // & (HARDENED_OFFSET - 1)
-    assert(childIndex < HARDENED_OFFSET, 'Invalid index')
-    if (hardened) childIndex += HARDENED_OFFSET
-
+  bip32path.fromString(path, true).toPathArray().forEach(function (childIndex) {
     hdkey = hdkey.deriveChild(childIndex)
   })
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "standard": "6.x"
   },
   "dependencies": {
+    "bip32-path": "^0.4.2",
     "coinstring": "^2.0.0",
     "secp256k1": "^3.0.1"
   },


### PR DESCRIPTION
@fanatid thought this might be merged

Any improvements to `bippath` are also welcome. It aims to be a very strict validator.
