### PR TITLE
test: include derivation test when private key has leading zeros

### DIFF
--- a/test/hdkey.test.js
+++ b/test/hdkey.test.js
@@ -140,6 +140,16 @@ describe('hdkey', function () {
     })
   })
 
+  describe('> when private key has leading zeros', function () {
+    it('will include leading zeros when hashing to derive child', function () {
+      var key = 'xprv9s21ZrQH143K3ckY9DgU79uMTJkQRLdbCCVDh81SnxTgPzLLGax6uHeBULTtaEtcAvKjXfT7ZWtHzKjTpujMkUd9dDb8msDeAfnJxrgAYhr'
+      var hdkey = HDKey.fromExtendedKey(key)
+      assert.equal(hdkey.privateKey.toString('hex'), '00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd')
+      var derived = hdkey.derive("m/44'/0'/0'/0/0'")
+      assert.equal(derived.privateKey.toString('hex'), '3348069561d2a0fb925e74bf198762acc47dce7db27372257d2d959a9e6f8aeb')
+    })
+  })
+
   describe('> when private key is null', function () {
     it('privateExtendedKey should return null and not throw', function () {
       var seed = '000102030405060708090a0b0c0d0e0f'


### PR DESCRIPTION
- Tests derivation implementation for bip32 compliance when private key has leading zeros as it's possible that the private key could be represented with less than 32 bytes. The correct implementation always uses 32 bytes for the private key in the sha512 hash.
- Uses test case added at bitcore-lib in https://github.com/bitpay/bitcore-lib/pull/97
- Test case verified against libbtc at https://github.com/braydonf/libbtc/commits/cross-ref