### PR TITLE
fix: derive will error when a path does not start with "m/"

### DIFF
--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -78,7 +78,7 @@ HDKey.prototype.derive = function (path) {
   var hdkey = this
   entries.forEach(function (c, i) {
     if (i === 0) {
-      assert(c, 'm', 'Invalid path')
+      assert(/^[mM]{1}/.test(c), 'Path must start with "m" or "M"')
       return
     }
 

--- a/test/hdkey.test.js
+++ b/test/hdkey.test.js
@@ -192,4 +192,23 @@ describe('hdkey', function () {
       assert.ok(!masterKey.privateExtendedKey, 'xpriv is falsy')
     })
   })
+
+  describe(' - when the path given to derive contains only the master extended key', function () {
+    const hdKeyInstance = HDKey.fromMasterSeed(Buffer.from(fixtures.valid[0].seed, 'hex'))
+
+    it('should return the same hdkey instance', function () {
+      assert.equal(hdKeyInstance.derive('m'), hdKeyInstance)
+      assert.equal(hdKeyInstance.derive('M'), hdKeyInstance)
+      assert.equal(hdKeyInstance.derive("m'"), hdKeyInstance)
+      assert.equal(hdKeyInstance.derive("M'"), hdKeyInstance)
+    })
+  })
+
+  describe(' - when the path given to derive does not begin with master extended key', function () {
+    it('should throw an error', function () {
+      assert.throws(function () {
+        HDKey.prototype.derive('123')
+      }, /Path must start with "m" or "M"/)
+    })
+  })
 })


### PR DESCRIPTION
Was working through some tests while using this library and noticed that the assert statement for the first section of `path` was incorrect. 

This lead to a closer look and I believe that the only valid first character is `m`.

Noticed another PR that would have cleared this up but it seems stuck / forgotten
https://github.com/cryptocoinjs/hdkey/pull/6. 

What do you think @jprichardson @axic ?