### PR TITLE
use ripemd160 instead of rmd160 for electron 4.0 uses BoringSSL

### DIFF
--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -235,7 +235,7 @@ function serialize (hdkey, version, key) {
 
 function hash160 (buf) {
   var sha = crypto.createHash('sha256').update(buf).digest()
-  return crypto.createHash('rmd160').update(sha).digest()
+  return crypto.createHash('ripemd160').update(sha).digest()
 }
 
 HDKey.HARDENED_OFFSET = HARDENED_OFFSET


### PR DESCRIPTION
We are working on an Electron 4.0 project.
Electron 4.0 uses BoringSSL and removed the alias(`rmd160` -> `ripemd160`).
We replaced `rmd160` with `ripemd160` which works in both OpenSSL and BoringSSL.