### PR TITLE
Don't promote deprecated Buffer usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Usage
 ```js
 var HDKey = require('hdkey')
 var seed = 'a0c42a9c3ac6abf2ba6a9946ae83af18f51bf1c9fa7dacc4c92513cc4dd015834341c775dcd4c0fac73547c5662d81a9e9361a0aac604a73a321bd9103bce8af'
-var hdkey = HDKey.fromMasterSeed(new Buffer(seed, 'hex'))
+var hdkey = HDKey.fromMasterSeed(Buffer.from(seed, 'hex'))
 console.log(hdkey.privateExtendedKey)
 // => 'xprv9s21ZrQH143K2SKJK9EYRW3Vsg8tWVHRS54hAJasj1eGsQXeWDHLeuu5hpLHRbeKedDJM4Wj9wHHMmuhPF8dQ3bzyup6R7qmMQ1i1FtzNEW'
 console.log(hdkey.publicExtendedKey)
@@ -36,7 +36,7 @@ Creates an `hdkey` object from a master seed buffer. Accepts an optional `versio
 
 ```js
 var seed = 'a0c42a9c3ac6abf2ba6a9946ae83af18f51bf1c9fa7dacc4c92513cc4dd015834341c775dcd4c0fac73547c5662d81a9e9361a0aac604a73a321bd9103bce8af'
-var hdkey = HDKey.fromMasterSeed(new Buffer(seed, 'hex'))
+var hdkey = HDKey.fromMasterSeed(Buffer.from(seed, 'hex'))
 ```
 
 ### `HDKey.fromExtendedKey(extendedKey[, versions])`


### PR DESCRIPTION
`new Buffer()` has been deprecated in Node.js due to surprising behaviour that can lead to major security vulnerabilities if you aren't fully aware how arguments of different type will be handled.

The example code in the readme should use `Buffer.from()` to avoid promoting the use of `new Buffer()` in userland code.