### PR TITLE
Remove dependency on coinstring (this package is deprecated and does …

### DIFF
--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -1,7 +1,8 @@
 var assert = require('assert')
+var b58 = require('b58')
 var Buffer = require('safe-buffer').Buffer
+var createHash = require('create-hash')
 var crypto = require('crypto')
-var cs = require('coinstring')
 var secp256k1 = require('secp256k1')
 
 var MASTER_SECRET = Buffer.from('Bitcoin seed', 'utf8')
@@ -58,14 +59,14 @@ Object.defineProperty(HDKey.prototype, 'publicKey', {
 
 Object.defineProperty(HDKey.prototype, 'privateExtendedKey', {
   get: function () {
-    if (this._privateKey) return cs.encode(serialize(this, this.versions.private, Buffer.concat([Buffer.alloc(1, 0), this.privateKey])))
+    if (this._privateKey) return encode(serialize(this, this.versions.private, Buffer.concat([Buffer.alloc(1, 0), this.privateKey])))
     else return null
   }
 })
 
 Object.defineProperty(HDKey.prototype, 'publicExtendedKey', {
   get: function () {
-    return cs.encode(serialize(this, this.versions.public, this.publicKey))
+    return encode(serialize(this, this.versions.public, this.publicKey))
   }
 })
 
@@ -190,7 +191,7 @@ HDKey.fromExtendedKey = function (base58key, versions) {
   versions = versions || BITCOIN_VERSIONS
   var hdkey = new HDKey(versions)
 
-  var keyBuffer = cs.decode(base58key)
+  var keyBuffer = decode(base58key)
 
   var version = keyBuffer.readUInt32BE(0)
   assert(version === versions.private || version === versions.public, 'Version mismatch: does not match private or public')
@@ -236,6 +237,60 @@ function serialize (hdkey, version, key) {
 function hash160 (buf) {
   var sha = crypto.createHash('sha256').update(buf).digest()
   return crypto.createHash('ripemd160').update(sha).digest()
+}
+
+function encode (payload, version) {
+  if (Array.isArray(payload) || payload instanceof Uint8Array) {
+    payload = new Buffer(payload)
+  }
+
+  var buf
+  if (version != null) {
+    if (typeof version === 'number') {
+      version = new Buffer([version])
+    }
+    buf = Buffer.concat([version, payload])
+  } else {
+    buf = payload
+  }
+
+  var checksum = sha256x2(buf).slice(0, 4)
+  var result = Buffer.concat([buf, checksum])
+  return b58.encode(result)
+}
+
+function decode (base58str, version) {
+  var arr = b58.decode(base58str)
+  var buf = new Buffer(arr)
+  var versionLength
+
+  if (version == null) {
+    versionLength = 0
+  } else {
+    if (typeof version === 'number') version = new Buffer([version])
+
+    versionLength = version.length
+    var versionCompare = buf.slice(0, versionLength)
+    if (versionCompare.toString('hex') !== version.toString('hex')) {
+      throw new Error('Invalid version')
+    }
+  }
+
+  var checksum = buf.slice(-4)
+  var endPos = buf.length - 4
+  var bytes = buf.slice(0, endPos)
+
+  var newChecksum = sha256x2(bytes).slice(0, 4)
+  if (checksum.toString('hex') !== newChecksum.toString('hex')) {
+    throw new Error('Invalid checksum')
+  }
+
+  return bytes.slice(versionLength)
+}
+
+function sha256x2 (buffer) {
+  var sha = createHash('sha256').update(buffer).digest()
+  return createHash('sha256').update(sha).digest()
 }
 
 HDKey.HARDENED_OFFSET = HARDENED_OFFSET

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "standard": "^7.1.1"
   },
   "dependencies": {
-    "coinstring": "^2.0.0",
+    "b58": "^4.0.3",
     "safe-buffer": "^5.1.1",
     "secp256k1": "^3.0.1"
   },


### PR DESCRIPTION
…not have an open source license) - it is only a thin wrapper around an MIT licensed package that does the actual base58 encoding/decoding