### PR TITLE
remove coinstring, replace with bs58check, update vulnerable dependencies

### DIFF
--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -1,7 +1,7 @@
 var assert = require('assert')
 var Buffer = require('safe-buffer').Buffer
 var crypto = require('crypto')
-var cs = require('coinstring')
+var bs58check = require('bs58check')
 var secp256k1 = require('secp256k1')
 
 var MASTER_SECRET = Buffer.from('Bitcoin seed', 'utf8')
@@ -58,14 +58,14 @@ Object.defineProperty(HDKey.prototype, 'publicKey', {
 
 Object.defineProperty(HDKey.prototype, 'privateExtendedKey', {
   get: function () {
-    if (this._privateKey) return cs.encode(serialize(this, this.versions.private, Buffer.concat([Buffer.alloc(1, 0), this.privateKey])))
+    if (this._privateKey) return bs58check.encode(serialize(this, this.versions.private, Buffer.concat([Buffer.alloc(1, 0), this.privateKey])))
     else return null
   }
 })
 
 Object.defineProperty(HDKey.prototype, 'publicExtendedKey', {
   get: function () {
-    return cs.encode(serialize(this, this.versions.public, this.publicKey))
+    return bs58check.encode(serialize(this, this.versions.public, this.publicKey))
   }
 })
 
@@ -190,7 +190,7 @@ HDKey.fromExtendedKey = function (base58key, versions) {
   versions = versions || BITCOIN_VERSIONS
   var hdkey = new HDKey(versions)
 
-  var keyBuffer = cs.decode(base58key)
+  var keyBuffer = bs58check.decode(base58key)
 
   var version = keyBuffer.readUInt32BE(0)
   assert(version === versions.private || version === versions.public, 'Version mismatch: does not match private or public')

--- a/package.json
+++ b/package.json
@@ -23,17 +23,17 @@
   "homepage": "https://github.com/cryptocoinjs/hdkey",
   "devDependencies": {
     "bigi": "^1.1.0",
-    "coveralls": "^2.10.0",
+    "coveralls": "^3.0.4",
     "ecurve": "^1.0.0",
-    "istanbul": "^0.3.17",
-    "mocha": "^2.2.5",
+    "istanbul": "^0.4.5",
+    "mocha": "^6.1.4",
     "mocha-lcov-reporter": "0.0.1",
-    "mochify": "^2.10.0",
+    "mochify": "^6.3.0",
     "secure-random": "^1.0.0",
     "standard": "^7.1.1"
   },
   "dependencies": {
-    "coinstring": "^2.0.0",
+    "bs58check": "^2.1.2",
     "safe-buffer": "^5.1.1",
     "secp256k1": "^3.0.1"
   },


### PR DESCRIPTION
I implemented the bs59check drop-in replacement for coinstring as discussed in https://github.com/cryptocoinjs/hdkey/pull/29

I also updated all vulnerable dependencies. All tests pass and `browser-test` `coveralls` at least behave identically although I don't have the environment to try them out completely.