### PR TITLE
update secp256k1 to v4.0

### DIFF
--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -35,7 +35,7 @@ Object.defineProperty(HDKey.prototype, 'privateKey', {
     assert(secp256k1.privateKeyVerify(value) === true, 'Invalid private key')
 
     this._privateKey = value
-    this._publicKey = secp256k1.publicKeyCreate(value, true)
+    this._publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true))
     this._identifier = hash160(this.publicKey)
     this._fingerprint = this._identifier.slice(0, 4).readUInt32BE(0)
   }
@@ -49,7 +49,7 @@ Object.defineProperty(HDKey.prototype, 'publicKey', {
     assert(value.length === 33 || value.length === 65, 'Public key must be 33 or 65 bytes.')
     assert(secp256k1.publicKeyVerify(value) === true, 'Invalid public key')
 
-    this._publicKey = secp256k1.publicKeyConvert(value, true) // force compressed point
+    this._publicKey = Buffer.from(secp256k1.publicKeyConvert(value, true)) // force compressed point
     this._identifier = hash160(this.publicKey)
     this._fingerprint = this._identifier.slice(0, 4).readUInt32BE(0)
     this._privateKey = null
@@ -125,7 +125,7 @@ HDKey.prototype.deriveChild = function (index) {
   if (this.privateKey) {
     // ki = parse256(IL) + kpar (mod n)
     try {
-      hd.privateKey = secp256k1.privateKeyTweakAdd(this.privateKey, IL)
+      hd.privateKey = Buffer.from(secp256k1.privateKeyTweakAdd(this.privateKey, IL))
       // throw if IL >= n || (privateKey + IL) === 0
     } catch (err) {
       // In case parse256(IL) >= n or ki == 0, one should proceed with the next value for i
@@ -136,7 +136,7 @@ HDKey.prototype.deriveChild = function (index) {
     // Ki = point(parse256(IL)) + Kpar
     //    = G*IL + Kpar
     try {
-      hd.publicKey = secp256k1.publicKeyTweakAdd(this.publicKey, IL, true)
+      hd.publicKey = Buffer.from(secp256k1.publicKeyTweakAdd(this.publicKey, IL, true))
       // throw if IL >= n || (g**IL + publicKey) is infinity
     } catch (err) {
       // In case parse256(IL) >= n or Ki is the point at infinity, one should proceed with the next value for i
@@ -153,11 +153,15 @@ HDKey.prototype.deriveChild = function (index) {
 }
 
 HDKey.prototype.sign = function (hash) {
-  return secp256k1.sign(hash, this.privateKey).signature
+  return Buffer.from(secp256k1.ecdsaSign(hash, this.privateKey).signature)
 }
 
 HDKey.prototype.verify = function (hash, signature) {
-  return secp256k1.verify(hash, signature, this.publicKey)
+  return secp256k1.ecdsaVerify(
+    Uint8Array.from(signature),
+    Uint8Array.from(hash),
+    Uint8Array.from(this.publicKey)
+  )
 }
 
 HDKey.prototype.wipePrivateData = function () {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "bs58check": "^2.1.2",
     "safe-buffer": "^5.1.1",
-    "secp256k1": "^3.0.1"
+    "secp256k1": "^4.0.0"
   },
   "scripts": {
     "lint": "standard",

--- a/test/hdkey.test.js
+++ b/test/hdkey.test.js
@@ -130,10 +130,10 @@ describe('hdkey', function () {
 
       assert.throws(function () {
         hdkey.verify(Buffer.alloc(99), a)
-      }, /message length is invalid/)
+      }, /message.*length/)
       assert.throws(function () {
         hdkey.verify(ma, Buffer.alloc(99))
-      }, /signature length is invalid/)
+      }, /signature.*length/)
     })
   })
 


### PR DESCRIPTION
Since secp256k1 v4.0 use the [N-API](https://github.com/cryptocoinjs/secp256k1-node/pull/160), this can avoid some unexpected situations similar to when worker_thread calls binding and use Pure JS version

Try the following code, and run with `secp256k1@3.8` and `secp256k1@4.0`, you will find that in the worker_thread, the error caused by `Module did not self-register` will cause its performance to decrease due to the implementation of the JS version

```js
const { Worker, isMainThread } = require("worker_threads");

process.env.DEBUG = "*";

if (isMainThread) {
  new Worker(__filename);
  const secp256k1 = require("secp256k1");

} else {
  const secp256k1 = require("secp256k1");
}
```