### PR TITLE
Bug: Derive only takes string while deriveChild takes index

### DIFF
--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -129,7 +129,7 @@ HDKey.prototype.deriveChild = function (index) {
       // throw if IL >= n || (privateKey + IL) === 0
     } catch (err) {
       // In case parse256(IL) >= n or ki == 0, one should proceed with the next value for i
-      return this.derive(index + 1)
+      return this.deriveChild(index + 1)
     }
   // Public parent key -> public child key
   } else {
@@ -140,7 +140,7 @@ HDKey.prototype.deriveChild = function (index) {
       // throw if IL >= n || (g**IL + publicKey) is infinity
     } catch (err) {
       // In case parse256(IL) >= n or Ki is the point at infinity, one should proceed with the next value for i
-      return this.derive(index + 1, isHardened)
+      return this.deriveChild(index + 1)
     }
   }
 


### PR DESCRIPTION
I doubt anyone has ever hit this bug, but it's still a bug.

No clue how we could test for it though...