### PR TITLE
Prevent secp256k1@4.x from mutating internal values

### DIFF
--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -125,7 +125,7 @@ HDKey.prototype.deriveChild = function (index) {
   if (this.privateKey) {
     // ki = parse256(IL) + kpar (mod n)
     try {
-      hd.privateKey = Buffer.from(secp256k1.privateKeyTweakAdd(this.privateKey, IL))
+      hd.privateKey = Buffer.from(secp256k1.privateKeyTweakAdd(Buffer.from(this.privateKey), IL))
       // throw if IL >= n || (privateKey + IL) === 0
     } catch (err) {
       // In case parse256(IL) >= n or ki == 0, one should proceed with the next value for i
@@ -136,7 +136,7 @@ HDKey.prototype.deriveChild = function (index) {
     // Ki = point(parse256(IL)) + Kpar
     //    = G*IL + Kpar
     try {
-      hd.publicKey = Buffer.from(secp256k1.publicKeyTweakAdd(this.publicKey, IL, true))
+      hd.publicKey = Buffer.from(secp256k1.publicKeyTweakAdd(Buffer.from(this.publicKey), IL, true))
       // throw if IL >= n || (g**IL + publicKey) is infinity
     } catch (err) {
       // In case parse256(IL) >= n or Ki is the point at infinity, one should proceed with the next value for i

--- a/test/hdkey.test.js
+++ b/test/hdkey.test.js
@@ -253,4 +253,44 @@ describe('hdkey', function () {
       assert.equal(hdkey.publicExtendedKey, fixtures.valid[0].public)
     })
   })
+
+  describe('Deriving a child key does not mutate the internal state', function () {
+    it('should not mutate it when deriving with a private key', function () {
+      const hdkey = HDKey.fromExtendedKey(fixtures.valid[0].private)
+      const path = 'm/123'
+      const privateKeyBefore = hdkey.privateKey.toString('hex')
+
+      const child = hdkey.derive(path)
+      assert.equal(hdkey.privateKey.toString('hex'), privateKeyBefore)
+
+      const child2 = hdkey.derive(path)
+      assert.equal(hdkey.privateKey.toString('hex'), privateKeyBefore)
+
+      const child3 = hdkey.derive(path)
+      assert.equal(hdkey.privateKey.toString('hex'), privateKeyBefore)
+
+      assert.equal(child.privateKey.toString('hex'), child2.privateKey.toString('hex'))
+      assert.equal(child2.privateKey.toString('hex'), child3.privateKey.toString('hex'))
+    })
+
+    it('should not mutate it when deriving without a private key', function () {
+      const hdkey = HDKey.fromExtendedKey(fixtures.valid[0].private)
+      const path = 'm/123/123/123'
+      hdkey.wipePrivateData()
+
+      const publicKeyBefore = hdkey.publicKey.toString('hex')
+
+      const child = hdkey.derive(path)
+      assert.equal(hdkey.publicKey.toString('hex'), publicKeyBefore)
+
+      const child2 = hdkey.derive(path)
+      assert.equal(hdkey.publicKey.toString('hex'), publicKeyBefore)
+
+      const child3 = hdkey.derive(path)
+      assert.equal(hdkey.publicKey.toString('hex'), publicKeyBefore)
+
+      assert.equal(child.publicKey.toString('hex'), child2.publicKey.toString('hex'))
+      assert.equal(child2.publicKey.toString('hex'), child3.publicKey.toString('hex'))
+    })
+  })
 })


### PR DESCRIPTION
Hi,

We discovered a small bug in this library when integrating it into ethereumjs-wallet. You can read more about it here: https://github.com/ethereumjs/ethereumjs-wallet/pull/127

The problem was that `secp256k1` v4 mutates some values in place. v3 didn't. When upgrading this library, these method calls weren't updated so deriving a child key was sometimes modifying the private/public keys. 

This PR fixes this bug, and adds some tests to prevent it from happening again.