### PR TITLE
docs(README): add BIP44 & WIF examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ console.log(childkey.publicExtendedKey)
 // -> "xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon"
 ```
 
+Newer, "hardened" derivation paths look like this:
+
+```js
+// as defined by BIP-44
+var childkey = hdkey.derive("m/44'/0'/0'/0'/0/0");
+```
+
+To convert to Base58Check and WIF addresses:
+
+```js
+var Base58check = require('base58check');
+
+var addr = Base58Check.encode(childkey.pubKeyHash, prefix = '00');
+
+var compressed = '01';
+var wif = Base58Check.encode(
+  childkey.privateKey.toString('hex') + compressed,
+  prefix = '00',
+);
+```
+
 ### `hdkey.sign(hash)`
 
 Signs the buffer `hash` with the private key using `secp256k1` and returns the signature as a buffer.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ var addr = Base58Check.encode(childkey.pubKeyHash, prefix = '00');
 var compressed = '01';
 var wif = Base58Check.encode(
   childkey.privateKey.toString('hex') + compressed,
-  prefix = '00',
+  prefix = '80',
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ A JavaScript component for [BIP32](https://github.com/bitcoin/bips/blob/master/b
 Installation
 ------------
 
-    npm i --save hdkey
+```bash
+npm i --save hdkey
+```
 
 
 Usage
@@ -80,21 +82,7 @@ Newer, "hardened" derivation paths look like this:
 
 ```js
 // as defined by BIP-44
-var childkey = hdkey.derive("m/44'/0'/0'/0'/0/0");
-```
-
-To convert to Base58Check and WIF addresses:
-
-```js
-var Base58check = require('base58check');
-
-var addr = Base58Check.encode(childkey.pubKeyHash, prefix = '00');
-
-var compressed = '01';
-var wif = Base58Check.encode(
-  childkey.privateKey.toString('hex') + compressed,
-  prefix = '80',
-);
+var childkey = hdkey.derive("m/44'/0'/0'/0/0");
 ```
 
 ### `hdkey.sign(hash)`


### PR DESCRIPTION
Removed this info, which is still valuable info:

## To convert to Base58Check and WIF addresses:

```js
var Base58check = require('base58check');

var addr = Base58Check.encode(childkey.pubKeyHash, prefix = '00');

var compressed = '01';
var wif = Base58Check.encode(
  childkey.privateKey.toString('hex') + compressed,
  prefix = '80',
);
```