### PR TITLE
Fix HDKey.sign method arguments types

### DIFF
--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -153,7 +153,7 @@ HDKey.prototype.deriveChild = function (index) {
 }
 
 HDKey.prototype.sign = function (hash) {
-  return Buffer.from(secp256k1.ecdsaSign(hash, this.privateKey).signature)
+  return Buffer.from(secp256k1.ecdsaSign(Uint8Array.from(hash), Uint8Array.from(this.privateKey)).signature)
 }
 
 HDKey.prototype.verify = function (hash, signature) {


### PR DESCRIPTION
secp256k1.ecdsaSign() expects Uint8Arrays as arguments instead of Buffers