### PR TITLE
fix(node-v18): use ripemd160 package, which is not available in libssl3

### DIFF
--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -2,6 +2,7 @@ var assert = require('assert')
 var Buffer = require('safe-buffer').Buffer
 var crypto = require('crypto')
 var bs58check = require('bs58check')
+var RIPEMD160 = require('ripemd160')
 var secp256k1 = require('secp256k1')
 
 var MASTER_SECRET = Buffer.from('Bitcoin seed', 'utf8')
@@ -239,7 +240,7 @@ function serialize (hdkey, version, key) {
 
 function hash160 (buf) {
   var sha = crypto.createHash('sha256').update(buf).digest()
-  return crypto.createHash('ripemd160').update(sha).digest()
+  return new RIPEMD160().update(sha).digest()
 }
 
 HDKey.HARDENED_OFFSET = HARDENED_OFFSET

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "bs58check": "^2.1.2",
+    "ripemd160": "^2.0.2",
     "safe-buffer": "^5.1.1",
     "secp256k1": "^4.0.0"
   },


### PR DESCRIPTION
Node v18 drops support for a number if insecure and vulnerable crypto algorithms, including `ripemd160`.

The only remedy is to re-install the necessary insecure algorithm as a standalone package.