### PR TITLE
chore: perf improvement

### DIFF
--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -48,8 +48,13 @@ Object.defineProperty(HDKey.prototype, 'publicKey', {
   set: function (value) {
     assert(value.length === 33 || value.length === 65, 'Public key must be 33 or 65 bytes.')
     assert(secp256k1.publicKeyVerify(value) === true, 'Invalid public key')
-
-    this._publicKey = Buffer.from(secp256k1.publicKeyConvert(value, true)) // force compressed point
+    
+    if (value.length === 65) {
+      // force compressed point (performs public key verification)
+      this._publicKey = Buffer.from(secp256k1.publicKeyConvert(value, true))
+    } else {
+      this._publicKey = Buffer.from(value)
+    }
     this._identifier = hash160(this.publicKey)
     this._fingerprint = this._identifier.slice(0, 4).readUInt32BE(0)
     this._privateKey = null


### PR DESCRIPTION
This PR avoids calling `publicKeyConvert` because they are really slow using a pure BN.js implementation.

