### PR TITLE
perf: allow skipping public key verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ var hdkey = HDKey.fromMasterSeed(Buffer.from(seed, 'hex'))
 
 ### `HDKey.fromExtendedKey(extendedKey[, versions, skipVerification])`
 
-Creates an `hdkey` object from a `xprv` or `xpub` extended key string. Accepts an optional `versions` object.
+Creates an `hdkey` object from a `xprv` or `xpub` extended key string. Accepts an optional `versions` object & an optional `skipVerification` boolean. If `skipVerification` is set to true, then the provided public key's x (and y if uncompressed) coordinate will not will be verified to be on the curve.
 
 ```js
 var key = 'xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j'

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var seed = 'a0c42a9c3ac6abf2ba6a9946ae83af18f51bf1c9fa7dacc4c92513cc4dd015834341
 var hdkey = HDKey.fromMasterSeed(Buffer.from(seed, 'hex'))
 ```
 
-### `HDKey.fromExtendedKey(extendedKey[, versions])`
+### `HDKey.fromExtendedKey(extendedKey[, versions, skipVerification])`
 
 Creates an `hdkey` object from a `xprv` or `xpub` extended key string. Accepts an optional `versions` object.
 

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -197,6 +197,7 @@ HDKey.fromMasterSeed = function (seedBuffer, versions) {
 HDKey.fromExtendedKey = function (base58key, versions, skipVerification) {
   // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
   versions = versions || BITCOIN_VERSIONS
+  skipVerification = skipVerification || false
   var hdkey = new HDKey(versions)
 
   var keyBuffer = bs58check.decode(base58key)

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -41,6 +41,13 @@ Object.defineProperty(HDKey.prototype, 'privateKey', {
   }
 })
 
+function setPublicKey (hdkey, publicKey) {
+  hdkey._publicKey = Buffer.from(publicKey)
+  hdkey._identifier = hash160(publicKey)
+  hdkey._fingerprint = hdkey._identifier.slice(0, 4).readUInt32BE(0)
+  hdkey._privateKey = null
+}
+
 Object.defineProperty(HDKey.prototype, 'publicKey', {
   get: function () {
     return this._publicKey
@@ -48,16 +55,9 @@ Object.defineProperty(HDKey.prototype, 'publicKey', {
   set: function (value) {
     assert(value.length === 33 || value.length === 65, 'Public key must be 33 or 65 bytes.')
     assert(secp256k1.publicKeyVerify(value) === true, 'Invalid public key')
-
-    if (value.length === 65) {
-      // force compressed point (performs public key verification)
-      this._publicKey = Buffer.from(secp256k1.publicKeyConvert(value, true))
-    } else {
-      this._publicKey = Buffer.from(value)
-    }
-    this._identifier = hash160(this.publicKey)
-    this._fingerprint = this._identifier.slice(0, 4).readUInt32BE(0)
-    this._privateKey = null
+    // force compressed point (performs public key verification)
+    const publicKey = (value.length === 65) ? secp256k1.publicKeyConvert(value, true) : value
+    setPublicKey(this, publicKey)
   }
 })
 
@@ -194,7 +194,7 @@ HDKey.fromMasterSeed = function (seedBuffer, versions) {
   return hdkey
 }
 
-HDKey.fromExtendedKey = function (base58key, versions) {
+HDKey.fromExtendedKey = function (base58key, versions, skipVerification) {
   // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
   versions = versions || BITCOIN_VERSIONS
   var hdkey = new HDKey(versions)
@@ -215,7 +215,11 @@ HDKey.fromExtendedKey = function (base58key, versions) {
     hdkey.privateKey = key.slice(1) // cut off first 0x0 byte
   } else {
     assert(version === versions.public, 'Version mismatch: version does not match public')
-    hdkey.publicKey = key
+    if (skipVerification) {
+      setPublicKey(hdkey, key)
+    } else {
+      hdkey.publicKey = key
+    }
   }
 
   return hdkey

--- a/test/hdkey.test.js
+++ b/test/hdkey.test.js
@@ -108,6 +108,21 @@ describe('hdkey', function () {
         assert.equal(hdkey.publicKey.toString('hex'), '024d902e1a2fc7a8755ab5b694c575fce742c48d9ff192e63df5193e4c7afe1f9c')
         assert.equal(hdkey.identifier.toString('hex'), '26132fdbe7bf89cbc64cf8dafa3f9f88b8666220')
       })
+
+      it('should parse it without verification', function () {
+        // m/0/2147483647'/1/2147483646'/2
+        var key = 'xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt'
+        var hdkey = HDKey.fromExtendedKey(key, null, false)
+        assert.equal(hdkey.versions.private, 0x0488ade4)
+        assert.equal(hdkey.versions.public, 0x0488b21e)
+        assert.equal(hdkey.depth, 5)
+        assert.equal(hdkey.parentFingerprint, 0x31a507b8)
+        assert.equal(hdkey.index, 2)
+        assert.equal(hdkey.chainCode.toString('hex'), '9452b549be8cea3ecb7a84bec10dcfd94afe4d129ebfd3b3cb58eedf394ed271')
+        assert.equal(hdkey.privateKey, null)
+        assert.equal(hdkey.publicKey.toString('hex'), '024d902e1a2fc7a8755ab5b694c575fce742c48d9ff192e63df5193e4c7afe1f9c')
+        assert.equal(hdkey.identifier.toString('hex'), '26132fdbe7bf89cbc64cf8dafa3f9f88b8666220')
+      })
     })
   })
 


### PR DESCRIPTION
The public key verification is rather slower in a pure JS mode. This PR introduces an argument  `skipVerification` to `fromExtendedKey()` to allow skipping the verification.$

builds on #52 

I did some quick benchmarks for thisPR. 

elliptic with BN.js: 8x performance increase with `skipVerification` set to true.
```
HDKey.fromExtendedKey(key) x 4,712 ops/sec ±4.69% (75 runs sampled)
HDKey.fromExtendedKey(key, null, true) x 39,627 ops/sec ±4.94% (71 runs sampled)
Fastest is HDKey.fromExtendedKey(key, null, true)
```

This allows `fromExtendedKey` to run just as quick as the native performance:
```
HDKey.fromExtendedKey(key) x 30,868 ops/sec ±4.71% (77 runs sampled)
HDKey.fromExtendedKey(key, null, true) x 38,105 ops/sec ±5.65% (67 runs sampled)
Fastest is HDKey.fromExtendedKey(key, null, true)
```